### PR TITLE
Add command registry and structured serial protocol responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ Use examples liberally, and show the expected output if you can. It's helpful to
 ## Support
 Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
 
+## Serial command reference
+
+The firmware exposes a line-delimited command interface over serial. Each response is emitted as a single JSON object with three fields:
+
+```
+{"cmd":"<verb>","status":"ok|error","message":"<detail>","data":{...optional...}}
+```
+
+Only the `data` object is optional and is present when a command returns structured measurements. Examples include position reports (`steps` and `mm`) and sensor reads (`counts` and `scaled`).
+
+### Supported verbs
+
+- Gantry and motion: `on`, `off`, `speed <steps_per_sec>`, `dir <0|1>`, `home`, `pos`, `goto <steps>`, `gotomm <mm>`, `move2 <steps>`, `move3 <steps>`, `speed23 <steps_per_sec>`, `m23 <steps2> <steps3>`, `link <steps>`, `pos2`, `pos3`.
+- Bases: `base <idx>`, `baseoff`, `whichbase`, `gobase <idx>`.
+- Servos and toolhead: `servopulse <channel> <us>`, `servo <channel> <angle>`, `servoslow <channel> <angle> [delay_ms]`, `raise`, `couple`.
+- RFID and encoder: `rfid on|off|once`, `rfid2 on|off|once [tries]`, `enc`, `enc on|off|zero`.
+- Syringe Fill Controller: `sfc.run`, `sfc.load`, `sfc.save`, `sfc.scanBases`, `sfc.scanbase <slot>`, `sfc.scanTool`, `sfc.status`, `sfc.cal.t.empty`, `sfc.cal.t.full <ml>`, `sfc.cal.t.save`, `sfc.tool.show`, `sfc.recipe.save`, `sfc.recipe.load`, `sfc.base.setemptypos`, `sfc.base.setfullpos`, `sfc.base.setmlfull <ml>`, `sfc.base.save`, `sfc.base.show`, `sfc.tool.setmlfull <ml>`.
+- Pots and pot-driven motion: `potraw <idx>`, `basepot <base_idx>`, `potmove <target_adc> <sps>`.
+
+The `status` field is `"ok"` when a command is accepted and `"error"` when rejected (for example, missing parameters or invalid base selection). Downstream consumers can key off the `cmd` and `status` fields without parsing human-readable log lines.
+
 ## Roadmap
 If you have ideas for releases in the future, it is a good idea to list them in the README.
 

--- a/syringe-filler-pio/include/app/DeviceActions.hpp
+++ b/syringe-filler-pio/include/app/DeviceActions.hpp
@@ -1,0 +1,91 @@
+#pragma once
+#include <Arduino.h>
+
+#include "app/SyringeFillController.hpp"
+
+namespace App {
+
+struct ActionResult {
+  bool ok;
+  String message;
+};
+
+struct PositionResult : public ActionResult {
+  long steps;
+  float mm;
+};
+
+namespace DeviceActions {
+
+// Gantry / axis 1
+PositionResult gantryPosition();
+ActionResult enableGantry(bool on);
+ActionResult setGantrySpeed(long sps);
+ActionResult setGantryDirection(int dirLevel);
+ActionResult homeGantry();
+ActionResult moveGantryToSteps(long targetSteps);
+ActionResult moveGantryToMm(float targetMm);
+
+// Bases
+ActionResult selectBase(uint8_t idx);
+uint8_t selectedBase();
+ActionResult moveToBase(uint8_t idx, long &targetSteps);
+
+// Servos / toolhead
+ActionResult setServoPulseRaw(int channel, int us);
+ActionResult setServoAngle(int channel, int angle);
+ActionResult setServoAngleSlow(int channel, int angle, int delayMs);
+ActionResult raiseToolhead();
+ActionResult coupleSyringes();
+
+// Secondary axes
+ActionResult moveAxis2(long steps);
+ActionResult moveAxis3(long steps);
+ActionResult setAxis23Speed(long sps);
+ActionResult moveAxisSync(long steps2, long steps3, bool requireBaseSelected);
+ActionResult linkAxis(long steps);
+PositionResult axis2Position();
+PositionResult axis3Position();
+
+// RFID
+ActionResult handleRfidCommand(const String &arg);
+ActionResult handleBaseRfidCommand(const String &arg);
+
+// Encoder
+ActionResult encoderStatus(long &count, float &mm, bool &hasReading);
+ActionResult encoderOn();
+ActionResult encoderOff();
+ActionResult encoderZero();
+
+// Syringe fill controller helpers
+ActionResult sfcScanBases(App::SyringeFillController &sfc);
+ActionResult sfcRunRecipe(App::SyringeFillController &sfc);
+ActionResult sfcLoadRecipe(App::SyringeFillController &sfc);
+ActionResult sfcSaveRecipe(App::SyringeFillController &sfc);
+ActionResult sfcStatus();
+ActionResult sfcScanBase(App::SyringeFillController &sfc, uint8_t slot);
+ActionResult sfcScanTool(App::SyringeFillController &sfc);
+ActionResult sfcCaptureToolEmpty(App::SyringeFillController &sfc);
+ActionResult sfcCaptureToolFull(App::SyringeFillController &sfc, float ml);
+ActionResult sfcSaveToolCalibration(App::SyringeFillController &sfc);
+ActionResult sfcShowTool(App::SyringeFillController &sfc);
+ActionResult sfcRecipeSave(App::SyringeFillController &sfc);
+ActionResult sfcRecipeLoad(App::SyringeFillController &sfc);
+ActionResult sfcSetBaseEmpty(App::SyringeFillController &sfc);
+ActionResult sfcSaveCurrentBase(App::SyringeFillController &sfc);
+ActionResult sfcShowCurrentBase(App::SyringeFillController &sfc);
+ActionResult sfcCaptureCurrentBaseEmpty(App::SyringeFillController &sfc);
+ActionResult sfcCaptureCurrentBaseFull(App::SyringeFillController &sfc);
+ActionResult sfcSetCurrentBaseMlFull(App::SyringeFillController &sfc, float ml);
+ActionResult sfcSetToolheadMlFull(App::SyringeFillController &sfc, float ml);
+
+// Pots
+ActionResult readPot(uint8_t idx, uint16_t &counts, uint16_t &scaled);
+ActionResult readBasePot(uint8_t base, uint8_t &potIdx, uint16_t &counts, uint16_t &scaled);
+
+// Pot-driven motion
+ActionResult potMove(uint16_t target, long sps);
+
+}  // namespace DeviceActions
+}  // namespace App
+


### PR DESCRIPTION
## Summary
- introduce a command descriptor registry in the command router and route verbs without chained conditionals
- add reusable device action helpers for gantry, bases, servos, RFID, and SFC flows
- emit JSON-formatted command responses and document supported verbs in the README

## Testing
- not run (platform-specific firmware environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694292d1dd108328b92540adca83109b)