### PR TITLE
Use ratio-based calibration points with interpolation for syringe pots

### DIFF
--- a/syringe-filler-pio/include/app/Syringe.hpp
+++ b/syringe-filler-pio/include/app/Syringe.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <Arduino.h>
+#include <math.h>
 
 namespace App {
 
@@ -16,18 +17,52 @@ enum class SyringeRole : uint8_t {
 // Calibration (persisted in NVS)
 // ----------------------------------------------------
 struct PotCalibration {
-  uint16_t adcEmpty = 0;     // raw ADC at 0 mL
-  uint16_t adcFull  = 4095;  // raw ADC at max mL
-  float    mlFull   = 10.1f; // how many mL does adcFull mean?
-  float    steps_mL = 1.01f; //calibrated steps per mL
+  struct CalibrationPoint {
+    float volume_ml = 0.0f;
+    float ratio     = 0.0f; // V_channel / V_ref (0..1 or 0..100)
+  };
 
-  float rawToMl(uint16_t raw) const {
-    int32_t span = (int32_t)adcFull - (int32_t)adcEmpty;
-    if (span <= 0) return 0.0f;
-    float t = ((int32_t)raw - (int32_t)adcEmpty) / (float)span;
-    if (t < 0.0f) t = 0.0f;
-    if (t > 1.0f) t = 1.0f;
-    return t * mlFull;
+  static constexpr uint8_t kMaxPoints = 8;
+  uint8_t         pointCount = 0;
+  CalibrationPoint points[kMaxPoints];
+  float           steps_mL = 1.01f; // calibrated steps per mL
+
+  bool addPoint(float volume_ml, float ratio) {
+    if (!isfinite(volume_ml) || !isfinite(ratio)) return false;
+    constexpr float kEps = 1e-4f;
+    for (uint8_t i = 0; i < pointCount; ++i) {
+      if (fabsf(points[i].ratio - ratio) <= kEps) {
+        points[i].volume_ml = volume_ml;
+        return true;
+      }
+    }
+    if (pointCount >= kMaxPoints) return false;
+    uint8_t insertAt = pointCount;
+    while (insertAt > 0 && ratio < points[insertAt - 1].ratio) {
+      points[insertAt] = points[insertAt - 1];
+      --insertAt;
+    }
+    points[insertAt] = {volume_ml, ratio};
+    ++pointCount;
+    return true;
+  }
+
+  float ratioToMl(float ratio) const {
+    if (pointCount == 0) return 0.0f;
+    if (pointCount == 1) return points[0].volume_ml;
+    if (ratio <= points[0].ratio) return points[0].volume_ml;
+    for (uint8_t i = 1; i < pointCount; ++i) {
+      if (ratio <= points[i].ratio) {
+        const float r0 = points[i - 1].ratio;
+        const float r1 = points[i].ratio;
+        const float v0 = points[i - 1].volume_ml;
+        const float v1 = points[i].volume_ml;
+        if (fabsf(r1 - r0) <= 1e-6f) return v0;
+        const float t = (ratio - r0) / (r1 - r0);
+        return v0 + (v1 - v0) * t;
+      }
+    }
+    return points[pointCount - 1].volume_ml;
   }
 };
 

--- a/syringe-filler-pio/include/app/SyringeFillController.hpp
+++ b/syringe-filler-pio/include/app/SyringeFillController.hpp
@@ -50,8 +50,8 @@ private:
   float    readToolheadVolumeMl();
   float    readBaseVolumeMl(uint8_t slot);
   bool     transferFromBase(uint8_t slot, float ml);
-  uint16_t readToolheadRawADC();
-  uint16_t readBaseRawADC(uint8_t slot);
+  float    readToolheadRatio();
+  float    readBaseRatio(uint8_t slot);
 
   Syringe m_toolhead;
   Syringe m_bases[Bases::kCount];
@@ -59,7 +59,7 @@ private:
   App::PotCalibration m_toolCal;   // loaded from NVS via Util::loadCalibration()
   bool m_toolCalValid = false;
 
-  static float mlFromCounts_(const App::PotCalibration& cal, uint16_t counts);
+  static float mlFromRatio_(const App::PotCalibration& cal, float ratio);
 
   uint8_t  m_baseToPot[Bases::kCount];
   int8_t  m_currentSlot = -1;

--- a/syringe-filler-pio/src/util/Storage.cpp
+++ b/syringe-filler-pio/src/util/Storage.cpp
@@ -49,13 +49,13 @@ bool nvsLoadBlob(const char* ns, const char* key, void* data, size_t len) {
 
 namespace Util {
 
-struct CalBlobV1 {
+struct CalBlobV2 {
   uint16_t version;
   App::PotCalibration cal;
   uint32_t crc;
 };
 
-struct BaseBlobV1 {
+struct BaseBlobV2 {
   uint16_t version;
   Util::BaseMeta meta;
   App::PotCalibration cal;
@@ -73,21 +73,21 @@ bool initStorage() {
 
 // ---------------------- calibration ----------------------
 bool loadCalibration(uint32_t rfid, App::PotCalibration& out) {
-  CalBlobV1 blob;
+  CalBlobV2 blob;
   String key = rfidKey(rfid, ":cal");
   if (!nvsLoadBlob("cal", key.c_str(), &blob, sizeof(blob))) return false;
   uint32_t saved = blob.crc;
   blob.crc = 0;
   uint32_t calc = crc32_acc(reinterpret_cast<uint8_t*>(&blob), sizeof(blob));
   if (saved != calc) return false;
-  if (blob.version != 1) return false;
+  if (blob.version != 2) return false;
   out = blob.cal;
   return true;
 }
 
 bool saveCalibration(uint32_t rfid, const App::PotCalibration& cal) {
-  CalBlobV1 blob;
-  blob.version = 1;
+  CalBlobV2 blob;
+  blob.version = 2;
   blob.cal     = cal;
   blob.crc     = 0;
   blob.crc     = crc32_acc(reinterpret_cast<uint8_t*>(&blob), sizeof(blob));
@@ -97,22 +97,22 @@ bool saveCalibration(uint32_t rfid, const App::PotCalibration& cal) {
 
 // ---------------------- base meta ------------------------
 bool loadBase(uint32_t rfid, BaseMeta& meta, App::PotCalibration& cal) {
-  BaseBlobV1 blob;
+  BaseBlobV2 blob;
   String key = rfidKey(rfid, ":meta");
   if (!nvsLoadBlob("base", key.c_str(), &blob, sizeof(blob))) return false;
   uint32_t saved = blob.crc;
   blob.crc = 0;
   uint32_t calc = crc32_acc(reinterpret_cast<uint8_t*>(&blob), sizeof(blob));
   if (saved != calc) return false;
-  if (blob.version != 1) return false;
+  if (blob.version != 2) return false;
   meta = blob.meta;
   cal  = blob.cal;
   return true;
 }
 
 bool saveBase(uint32_t rfid, const BaseMeta& meta, const App::PotCalibration& cal) {
-  BaseBlobV1 blob;
-  blob.version = 1;
+  BaseBlobV2 blob;
+  blob.version = 2;
   blob.meta    = meta;
   blob.cal     = cal;
   blob.crc     = 0;


### PR DESCRIPTION
### Motivation

- Replace fragile raw-ADC-based calibration fields with ratiometric calibration so measurements are stable vs VREF changes.
- Allow storing multiple calibration points `{volume_ml, ratio}` and compute volumes by linear interpolation between adjacent points.
- Use the `Pots` API (ratiometric `Pots::percent()`) instead of raw ADC counts throughout the syringe controller.
- Make debug prints and persisted blobs reflect the new calibration format.

### Description

- Replaced the old `PotCalibration` fields (`adcEmpty`, `adcFull`, `mlFull`) with a points-based format: `struct PotCalibration` now contains `CalibrationPoint { volume_ml, ratio }`, `pointCount`, and `points[]` plus `steps_mL`.
- Added helpers on `PotCalibration`: `addPoint(float volume_ml, float ratio)` and `ratioToMl(float ratio)` (linear interpolation between adjacent points).
- Updated `SyringeFillController` to read ratios and manage calibration points:
  - New methods: `readToolheadRatio()` and `readBaseRatio()` which call `Pots::percent()`.
  - Replaced usages of raw-ADC helpers with `addPoint(...)` and `ratioToMl(...)` (e.g. `captureToolheadEmpty`, `captureToolheadFull`, `captureBaseEmpty`, `captureBaseFull`, `setCurrentBaseMlFull`, `setToolheadMlFull`).
  - Replaced `mlFromCounts_` with `mlFromRatio_` and wired it to use `ratioToMl`.
  - Adjusted `readToolheadVolumeMl()` and `readBaseVolumeMl()` to compute volume from current ratio.
- Updated debug output in `printToolheadInfo` and `printBaseInfo` to display the list of calibration points and ratios instead of raw counts.
- Bumped NVS blob format identifiers in `util/Storage.cpp` (`CalBlobV2` / `BaseBlobV2`) so the new `PotCalibration` layout is stored/loaded; `saveCalibration` / `saveBase` now persist the new format.
- Minor: added `#include <math.h>` to support `isfinite`/`fabsf` used by the new helpers.

### Testing

- No automated tests were run as part of this change.
- Code changes were limited to calibration handling, controller reads, and NVS blob layout. Manual runtime validation is recommended: exercise `sfc.captureToolEmpty`, `sfc.captureToolFull`, `sfc.scanBase`, `sfc.captureBaseEmpty`, `sfc.captureBaseFull`, and `sfc.showTool` / `sfc.showCurrentBase` to verify point storage and computed volumes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694512b5fb1c8328bf441acfadac7f05)