### PR TITLE
Remove legacy two‑point calibration paths and simplify storage blobs

### DIFF
--- a/syringe-filler-pio/include/app/DeviceActions.hpp
+++ b/syringe-filler-pio/include/app/DeviceActions.hpp
@@ -56,25 +56,18 @@ ActionResult sfcSaveRecipe(App::SyringeFillController &sfc);
 ActionResult sfcStatus();
 ActionResult sfcScanBase(App::SyringeFillController &sfc, uint8_t slot);
 ActionResult sfcScanTool(App::SyringeFillController &sfc);
-ActionResult sfcCaptureToolEmpty(App::SyringeFillController &sfc);
-ActionResult sfcCaptureToolFull(App::SyringeFillController &sfc, float ml);
 ActionResult sfcCaptureToolCalPoint(App::SyringeFillController &sfc, float ml);
 ActionResult sfcSaveToolCalibration(App::SyringeFillController &sfc);
 ActionResult sfcShowTool(App::SyringeFillController &sfc);
 ActionResult sfcRecipeSave(App::SyringeFillController &sfc);
 ActionResult sfcRecipeLoad(App::SyringeFillController &sfc);
-ActionResult sfcSetBaseEmpty(App::SyringeFillController &sfc);
 ActionResult sfcSaveCurrentBase(App::SyringeFillController &sfc);
 ActionResult sfcShowCurrentBase(App::SyringeFillController &sfc);
-ActionResult sfcCaptureCurrentBaseEmpty(App::SyringeFillController &sfc);
-ActionResult sfcCaptureCurrentBaseFull(App::SyringeFillController &sfc);
 ActionResult sfcCaptureBaseCalPoint(App::SyringeFillController &sfc, float ml, int8_t slot);
 ActionResult sfcClearBaseCalPoints(App::SyringeFillController &sfc);
 ActionResult sfcClearToolCalPoints(App::SyringeFillController &sfc);
 ActionResult sfcForceBaseCalZero(App::SyringeFillController &sfc);
 ActionResult sfcForceToolCalZero(App::SyringeFillController &sfc);
-ActionResult sfcSetCurrentBaseMlFull(App::SyringeFillController &sfc, float ml);
-ActionResult sfcSetToolheadMlFull(App::SyringeFillController &sfc, float ml);
 
 // Pots
 ActionResult readPot(uint8_t idx, uint16_t &counts, uint16_t &scaled);

--- a/syringe-filler-pio/include/app/Syringe.hpp
+++ b/syringe-filler-pio/include/app/Syringe.hpp
@@ -24,13 +24,12 @@ struct PotCalibration {
 
   static constexpr uint8_t kMaxPoints = 8;
 
-  // Legacy-ish single-span fields (kept for compatibility / convenience)
+  // Single-span fields (kept for compatibility / convenience)
   uint16_t adcEmpty = 0;     // raw ADC at 0 mL
   uint16_t adcFull  = 4095;  // raw ADC at max mL
   float    mlFull   = 10.1f; // how many mL does adcFull mean?
 
   // Current multi-point model
-  bool             legacy     = false;
   uint8_t          pointCount = 0;
   CalibrationPoint points[kMaxPoints];
   float            steps_mL   = 1.01f; // calibrated steps per mL

--- a/syringe-filler-pio/include/app/SyringeFillController.hpp
+++ b/syringe-filler-pio/include/app/SyringeFillController.hpp
@@ -17,21 +17,10 @@ public:
   int8_t currentSlot() const { return m_currentSlot; }
   void   printBaseInfo(uint8_t slot, Stream& s);
   bool   saveCurrentBaseToNVS();   // create/update entry for the base we’re parked at
-  bool captureBaseEmpty(uint8_t slot);
-  bool captureCurrentBaseEmpty() { 
-    return (m_currentSlot >= 0) ? captureBaseEmpty((uint8_t)m_currentSlot) : false;
-  }
-  bool captureBaseFull(uint8_t slot);
-  bool captureCurrentBaseFull() { 
-    return (m_currentSlot >= 0) ? captureBaseFull((uint8_t)m_currentSlot) : false;
-  }
   bool captureBaseCalibrationPoint(uint8_t slot, float ml, String& message);
   bool captureCurrentBaseCalibrationPoint(float ml, String& message) {
     return (m_currentSlot >= 0) ? captureBaseCalibrationPoint((uint8_t)m_currentSlot, ml, message) : false;
   }
-  bool getCurrentBaseMlFull(float& ml) const;
-  bool setCurrentBaseMlFull(float ml);
-  bool setToolheadMlFull(float ml);  
   bool clearCurrentBaseCalibrationPoints(String& message);
   bool clearToolheadCalibrationPoints(String& message);
   bool forceCurrentBaseCalibrationZero(String& message);
@@ -41,8 +30,6 @@ public:
   void runRecipe();
 
   // calibration for toolhead already here...
-  bool captureToolheadEmpty();
-  bool captureToolheadFull(float mlFull);
   bool captureToolheadCalibrationPoint(float ml, String& message);
   bool saveToolheadCalibration();
   bool printCurrentBaseInfo(Stream& s = Serial);

--- a/syringe-filler-pio/include/util/Storage.hpp
+++ b/syringe-filler-pio/include/util/Storage.hpp
@@ -26,7 +26,6 @@ struct CalPoint {
   float ratio = 0.0f;
 };
 
-constexpr uint8_t kCalPointCountLegacy = 2;
 constexpr uint8_t kCalPointCount = App::PotCalibration::kMaxPoints;
 
 bool initStorage();

--- a/syringe-filler-pio/src/app/CommandRouter.cpp
+++ b/syringe-filler-pio/src/app/CommandRouter.cpp
@@ -28,10 +28,7 @@ using App::DeviceActions::moveGantryToSteps;
 using App::DeviceActions::moveToBase;
 using App::DeviceActions::potMove;
 using App::DeviceActions::raiseToolhead;
-using App::DeviceActions::sfcCaptureCurrentBaseEmpty;
 using App::DeviceActions::sfcCaptureBaseCalPoint;
-using App::DeviceActions::sfcCaptureToolEmpty;
-using App::DeviceActions::sfcCaptureToolFull;
 using App::DeviceActions::sfcCaptureToolCalPoint;
 using App::DeviceActions::sfcClearBaseCalPoints;
 using App::DeviceActions::sfcClearToolCalPoints;
@@ -47,8 +44,6 @@ using App::DeviceActions::sfcSaveToolCalibration;
 using App::DeviceActions::sfcScanBase;
 using App::DeviceActions::sfcScanBases;
 using App::DeviceActions::sfcScanTool;
-using App::DeviceActions::sfcSetCurrentBaseMlFull;
-using App::DeviceActions::sfcSetToolheadMlFull;
 using App::DeviceActions::sfcShowCurrentBase;
 using App::DeviceActions::sfcShowTool;
 using App::DeviceActions::sfcStatus;
@@ -223,17 +218,6 @@ void handleSfcScanBase(const String &args) { printStructured("sfc.scanbase", sfc
 
 void handleSfcScanTool(const String &args) { printStructured("sfc.scanTool", sfcScanTool(g_sfc)); }
 
-void handleSfcCalTEmpty(const String &args) { printStructured("sfc.cal.t.empty", sfcCaptureToolEmpty(g_sfc)); }
-
-void handleSfcCalTFull(const String &args) {
-  float ml = args.toFloat();
-  if (ml <= 0.0f) {
-    printStructured("sfc.cal.t.full", {false, "usage: sfc.cal.t.full <ml>"});
-  } else {
-    printStructured("sfc.cal.t.full", sfcCaptureToolFull(g_sfc, ml));
-  }
-}
-
 void handleSfcCalTSave(const String &args) { printStructured("sfc.cal.t.save", sfcSaveToolCalibration(g_sfc)); }
 
 void handleSfcCalTPoint(const String &args) {
@@ -255,30 +239,9 @@ void handleSfcRecipeSave(const String &args) { printStructured("sfc.recipe.save"
 
 void handleSfcRecipeLoad(const String &args) { printStructured("sfc.recipe.load", sfcRecipeLoad(g_sfc)); }
 
-void handleSfcBaseSetEmptyPos(const String &args) {
-  ActionResult res = sfcCaptureBaseCalPoint(g_sfc, 0.0f, -1);
-  if (res.ok) {
-    res.message = "deprecated: use sfc.cal.base.point; " + res.message;
-  }
-  printStructured("sfc.base.setemptypos", res);
-}
-
 void handleSfcBaseSave(const String &args) { printStructured("sfc.base.save", sfcSaveCurrentBase(g_sfc)); }
 
 void handleSfcBaseShow(const String &args) { printStructured("sfc.base.show", sfcShowCurrentBase(g_sfc)); }
-
-void handleSfcBaseSetFullPos(const String &args) {
-  float ml = 0.0f;
-  if (!g_sfc.getCurrentBaseMlFull(ml)) {
-    printStructured("sfc.base.setfullpos", {false, "deprecated: set ml with sfc.cal.base.point <ml> [slot]"} );
-    return;
-  }
-  ActionResult res = sfcCaptureBaseCalPoint(g_sfc, ml, -1);
-  if (res.ok) {
-    res.message = "deprecated: use sfc.cal.base.point; " + res.message;
-  }
-  printStructured("sfc.base.setfullpos", res);
-}
 
 void handleSfcCalBasePoint(const String &args) {
   int sp = args.indexOf(' ');
@@ -316,24 +279,6 @@ void handleSfcCalBaseForceZero(const String &args) {
 
 void handleSfcCalToolForceZero(const String &args) {
   printStructured("sfc.cal.t.force0", sfcForceToolCalZero(g_sfc));
-}
-
-void handleSfcBaseSetMlFull(const String &args) {
-  float ml = args.toFloat();
-  if (ml <= 0.0f) {
-    printStructured("sfc.base.setmlfull", {false, "usage: sfc.base.setmlfull <ml>"});
-  } else {
-    printStructured("sfc.base.setmlfull", sfcSetCurrentBaseMlFull(g_sfc, ml));
-  }
-}
-
-void handleSfcToolSetMlFull(const String &args) {
-  float ml = args.toFloat();
-  if (ml <= 0.0f) {
-    printStructured("sfc.tool.setmlfull", {false, "usage: sfc.tool.setmlfull <ml>"});
-  } else {
-    printStructured("sfc.tool.setmlfull", sfcSetToolheadMlFull(g_sfc, ml));
-  }
 }
 
 void handlePotRaw(const String &args) {
@@ -392,8 +337,6 @@ const CommandDescriptor COMMANDS[] = {
     {"sfc.status", "sfc status", handleSfcStatus},
     {"sfc.scanbase", "scan a base slot", handleSfcScanBase},
     {"sfc.scanTool", "scan toolhead syringe", handleSfcScanTool},
-    {"sfc.cal.t.empty", "capture toolhead empty", handleSfcCalTEmpty},
-    {"sfc.cal.t.full", "capture toolhead full", handleSfcCalTFull},
     {"sfc.cal.t.save", "save toolhead calibration", handleSfcCalTSave},
     {"sfc.cal.t.point", "add toolhead calibration point <ml>", handleSfcCalTPoint},
     {"sfc.cal.t.clear", "clear toolhead calibration points", handleSfcCalToolClear},
@@ -401,15 +344,11 @@ const CommandDescriptor COMMANDS[] = {
     {"sfc.tool.show", "print toolhead info", handleSfcToolShow},
     {"sfc.recipe.save", "save toolhead recipe", handleSfcRecipeSave},
     {"sfc.recipe.load", "load toolhead recipe", handleSfcRecipeLoad},
-    {"sfc.base.setemptypos", "deprecated: use sfc.cal.base.point 0 [slot]", handleSfcBaseSetEmptyPos},
     {"sfc.base.save", "save current base", handleSfcBaseSave},
     {"sfc.base.show", "show current base", handleSfcBaseShow},
-    {"sfc.base.setfullpos", "deprecated: use sfc.cal.base.point <ml> [slot]", handleSfcBaseSetFullPos},
     {"sfc.cal.base.point", "add base calibration point <ml> [slot]", handleSfcCalBasePoint},
     {"sfc.cal.base.clear", "clear current base calibration points", handleSfcCalBaseClear},
     {"sfc.cal.base.force0", "force base calibration to 0 mL", handleSfcCalBaseForceZero},
-    {"sfc.base.setmlfull", "deprecated: use sfc.cal.base.point <ml> [slot]", handleSfcBaseSetMlFull},
-    {"sfc.tool.setmlfull", "deprecated: use sfc.cal.t.full <ml>", handleSfcToolSetMlFull},
     {"potraw", "read pot", handlePotRaw},
     {"basepot", "read base pot", handleBasePot},
     {"potmove", "pot driven move", handlePotMove},

--- a/syringe-filler-pio/src/app/DeviceActions.cpp
+++ b/syringe-filler-pio/src/app/DeviceActions.cpp
@@ -225,16 +225,6 @@ ActionResult sfcScanTool(App::SyringeFillController &sfc) {
   return {ok, ok ? "toolhead scan ok" : "toolhead scan failed"};
 }
 
-ActionResult sfcCaptureToolEmpty(App::SyringeFillController &sfc) {
-  bool ok = sfc.captureToolheadEmpty();
-  return {ok, ok ? "toolhead empty captured" : "capture empty failed"};
-}
-
-ActionResult sfcCaptureToolFull(App::SyringeFillController &sfc, float ml) {
-  bool ok = sfc.captureToolheadFull(ml);
-  return {ok, ok ? "toolhead full captured" : "capture full failed"};
-}
-
 ActionResult sfcCaptureToolCalPoint(App::SyringeFillController &sfc, float ml) {
   String message;
   bool ok = sfc.captureToolheadCalibrationPoint(ml, message);
@@ -255,11 +245,6 @@ ActionResult sfcRecipeSave(App::SyringeFillController &sfc) { return sfcSaveReci
 
 ActionResult sfcRecipeLoad(App::SyringeFillController &sfc) { return sfcLoadRecipe(sfc); }
 
-ActionResult sfcSetBaseEmpty(App::SyringeFillController &sfc) {
-  bool ok = sfc.captureBaseEmpty((uint8_t)sfc.currentSlot());
-  return {ok, ok ? "base empty captured" : "capture base empty failed"};
-}
-
 ActionResult sfcSaveCurrentBase(App::SyringeFillController &sfc) {
   bool ok = sfc.saveCurrentBaseToNVS();
   return {ok, ok ? "current base saved" : "save current base failed"};
@@ -272,16 +257,6 @@ ActionResult sfcShowCurrentBase(App::SyringeFillController &sfc) {
   }
   sfc.printBaseInfo((uint8_t)slot, Serial);
   return {true, "base info printed"};
-}
-
-ActionResult sfcCaptureCurrentBaseEmpty(App::SyringeFillController &sfc) {
-  bool ok = sfc.captureCurrentBaseEmpty();
-  return {ok, ok ? "base empty captured" : "capture base empty failed"};
-}
-
-ActionResult sfcCaptureCurrentBaseFull(App::SyringeFillController &sfc) {
-  bool ok = sfc.captureCurrentBaseFull();
-  return {ok, ok ? "base full captured" : "capture base full failed"};
 }
 
 ActionResult sfcCaptureBaseCalPoint(App::SyringeFillController &sfc, float ml, int8_t slot) {
@@ -320,16 +295,6 @@ ActionResult sfcForceToolCalZero(App::SyringeFillController &sfc) {
   String message;
   bool ok = sfc.forceToolheadCalibrationZero(message);
   return {ok, message.length() ? message : (ok ? "toolhead calibration forced to 0 mL" : "update failed")};
-}
-
-ActionResult sfcSetCurrentBaseMlFull(App::SyringeFillController &sfc, float ml) {
-  bool ok = sfc.setCurrentBaseMlFull(ml);
-  return {ok, ok ? "base ml full set (deprecated: use sfc.cal.base.point)" : "set base ml full failed"};
-}
-
-ActionResult sfcSetToolheadMlFull(App::SyringeFillController &sfc, float ml) {
-  bool ok = sfc.setToolheadMlFull(ml);
-  return {ok, ok ? "tool ml full set (deprecated)" : "set tool ml full failed"};
 }
 
 // Pots


### PR DESCRIPTION
### Motivation
- Remove legacy two‑point calibration codepaths and deprecated CLI helpers to keep the codebase focused on the multi‑point calibration model.
- Eliminate versioned/legacy NVS blob formats and the `legacy` flag so storage is consistent and easier to maintain.
- Preserve and continue to support the newer APIs such as `sfc.cal.base.point` and `sfc.cal.t.point` for arbitrary point calibration.
- Reduce complexity in `Storage.cpp` by consolidating calibration/base blob formats to a single layout.

### Description
- Deleted legacy calibration helpers and deprecated command handlers and removed corresponding `DeviceActions` and `CommandRouter` entries for commands like the old `sfc.cal.t.empty`, `sfc.cal.t.full`, `sfc.base.setemptypos`, and other single‑span helper paths.
- Removed the `legacy` field and references from the `PotCalibration` model in `include/app/Syringe.hpp` and updated callers to use only the point based API (`addPoint`, `pointCount`, etc.).
- Replaced versioned blob structs (`CalBlobV1/V2/V3`, `BaseBlobV1/V2`) with single `CalBlob` and `BaseBlob` structs in `src/util/Storage.cpp`, and simplified `loadCalibration`/`saveCalibration` and `loadBase`/`saveBase` to a single consistent format; also removed `kCalPointCountLegacy` from `include/util/Storage.hpp`.
- Cleaned up controller code in `src/app/SyringeFillController.cpp` to drop legacy code paths and messages, and kept/continued support for multi‑point capture via `captureToolheadCalibrationPoint` and `captureBaseCalibrationPoint` and the `sfc.cal.*` command handlers.

### Testing
- No automated tests were executed against these changes (no CI/unit tests were run as part of this change).
- A local commit was created containing the changes and files were updated without running build/test steps.
- Manual smoke/build verification was not performed by automation in this rollout.
- Recommend running the project build and any device integration tests after merging to validate NVS compatibility and CLI behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554c4935f483289f79131b2e4d0879)