### PR TITLE
Add pot ratio reporting, `pots` dump, and more verbose calibration logs

### DIFF
--- a/syringe-filler-pio/include/app/DeviceActions.hpp
+++ b/syringe-filler-pio/include/app/DeviceActions.hpp
@@ -71,6 +71,7 @@ ActionResult sfcForceToolCalZero(App::SyringeFillController &sfc);
 // Pots
 ActionResult readPot(uint8_t idx, uint16_t &counts, uint16_t &scaled);
 ActionResult readBasePot(uint8_t base, uint8_t &potIdx, uint16_t &counts, uint16_t &scaled);
+ActionResult readAllPots(String &data);
 
 // Pot-driven motion
 ActionResult potMove(uint16_t target, long sps);

--- a/syringe-filler-pio/src/app/CommandRouter.cpp
+++ b/syringe-filler-pio/src/app/CommandRouter.cpp
@@ -54,6 +54,7 @@ using App::DeviceActions::setServoAngle;
 using App::DeviceActions::setServoAngleSlow;
 using App::DeviceActions::setServoPulseRaw;
 using App::DeviceActions::readBasePot;
+using App::DeviceActions::readAllPots;
 using App::DeviceActions::readPot;
 
 namespace {
@@ -293,8 +294,18 @@ void handleBasePot(const String &args) {
   uint8_t potIdx = 0;
   uint16_t counts = 0, scaled = 0;
   ActionResult res = readBasePot((uint8_t)args.toInt(), potIdx, counts, scaled);
-  String data = "{\"base\":" + String(args.toInt()) + ",\"potIndex\":" + String(potIdx) + ",\"counts\":" + String(counts) + ",\"scaled\":" + String(scaled) + "}";
+  float percent = Pots::ratioFromCounts(counts);
+  float ratio = percent / 100.0f;
+  String data = "{\"base\":" + String(args.toInt()) + ",\"potIndex\":" + String(potIdx) + ",\"counts\":" + String(counts) + ",\"scaled\":" + String(scaled);
+  data += ",\"ratio\":" + String(ratio, 5) + ",\"percent\":" + String(percent, 3) + "}";
   printStructured("basepot", res, data);
+}
+
+void handlePotReport(const String &args) {
+  (void)args;
+  String data;
+  ActionResult res = readAllPots(data);
+  printStructured("pots", res, data);
 }
 
 void handlePotMove(const String &args) {
@@ -350,6 +361,7 @@ const CommandDescriptor COMMANDS[] = {
     {"cal.base.force0", "force base calibration to 0 mL", handleSfcCalBaseForceZero},
     {"potraw", "read pot", handlePotRaw},
     {"basepot", "read base pot", handleBasePot},
+    {"pots", "read all pots", handlePotReport},
     {"potmove", "pot driven move", handlePotMove},
 };
 

--- a/syringe-filler-pio/src/app/DeviceActions.cpp
+++ b/syringe-filler-pio/src/app/DeviceActions.cpp
@@ -307,6 +307,26 @@ ActionResult readBasePot(uint8_t base, uint8_t &potIdx, uint16_t &counts, uint16
   return {true, "base pot read"};
 }
 
+ActionResult readAllPots(String &data) {
+  String out = "[";
+  for (uint8_t i = 0; i < Pots::NUM_POTS; ++i) {
+    if (i > 0) {
+      out += ",";
+    }
+    uint16_t counts = Pots::readCounts(i);
+    float percent = Pots::ratioFromCounts(counts);
+    float ratio = percent / 100.0f;
+    out += "{\"index\":" + String(i);
+    out += ",\"counts\":" + String(counts);
+    out += ",\"ratio\":" + String(ratio, 5);
+    out += ",\"percent\":" + String(percent, 3);
+    out += "}";
+  }
+  out += "]";
+  data = "{\"pots\":" + out + "}";
+  return {true, "pot readings reported"};
+}
+
 // Pot-driven motion
 ActionResult potMove(uint16_t target, long sps) {
   bool ok = AxisPair::move2UntilPotSimple(target, sps);

--- a/syringe-filler-pio/src/app/SyringeCalibration.cpp
+++ b/syringe-filler-pio/src/app/SyringeCalibration.cpp
@@ -115,6 +115,23 @@ bool SyringeCalibration::captureToolheadCalibrationPoint(float ml, String& messa
   }
 
   float ratio = readToolheadRatio();
+  if (CAL_DBG) {
+    uint16_t counts = Pots::readCounts(TOOLHEAD_POT_IDX);
+    float percent = Pots::ratioFromCounts(counts);
+    float normalized = percent / 100.0f;
+    Serial.print("[SFC] cal.tool.point: toolhead RFID=0x");
+    Serial.print(m_toolhead.rfid, HEX);
+    Serial.print(" pot=");
+    Serial.print(TOOLHEAD_POT_IDX);
+    Serial.print(" counts=");
+    Serial.print(counts);
+    Serial.print(" ratioUsed=");
+    Serial.print(ratio, 4);
+    Serial.print(" ratioNormalized=");
+    Serial.print(normalized, 4);
+    Serial.print(" percent=");
+    Serial.println(percent, 2);
+  }
   bool ok = m_toolhead.cal.addPoint(ml, ratio);
   if (!ok) {
     message = (m_toolhead.cal.pointCount >= PotCalibration::kMaxPoints)
@@ -326,6 +343,23 @@ bool SyringeCalibration::captureBaseCalibrationPoint(uint8_t slot, float ml, Str
   if (!readBasePotRatio(slot, ratio, ratioMessage)) {
     message = ratioMessage;
     return false;
+  }
+  if (CAL_DBG) {
+    int8_t potIdx = getBasePotIndex(slot);
+    uint16_t counts = (potIdx >= 0) ? Pots::readCounts((uint8_t)potIdx) : 0;
+    float percent = Pots::ratioFromCounts(counts);
+    Serial.print("[SFC] cal.base.point: base slot=");
+    Serial.print(slot);
+    Serial.print(" RFID=0x");
+    Serial.print(sy.rfid, HEX);
+    Serial.print(" pot=");
+    Serial.print(potIdx);
+    Serial.print(" counts=");
+    Serial.print(counts);
+    Serial.print(" ratio=");
+    Serial.print(ratio, 4);
+    Serial.print(" percent=");
+    Serial.println(percent, 2);
   }
 
   CalibrationPoints& points = sy.calPoints;


### PR DESCRIPTION
### Motivation
- The `basepot` output lacked a ratiometric value tied to the live VREF, making calibration steps and diagnosis confusing. 
- There is a need to inspect all potentiometers and their ratios in one request to diagnose mapping issues across bases. 
- Calibration log output was insufficiently descriptive when saving calibration points, making it hard to tell which pot and base/RFID were involved. 

### Description
- Added a new device action `readAllPots` (declared in `DeviceActions.hpp` and implemented in `DeviceActions.cpp`) that returns a JSON payload with each pot's `index`, `counts`, `ratio`, and `percent`.
- Updated the `basepot` command in `CommandRouter.cpp` to include computed `ratio` (0..1) and `percent` (0..100) in its structured JSON output.
- Added a new command handler `pots` (registered in `CommandRouter.cpp`) that calls `readAllPots` and prints the consolidated pot report.
- Enhanced calibration debug logging in `SyringeCalibration.cpp` for `cal.tool.point` and `cal.base.point` to print the pot index, raw counts, ratio/percent, and associated RFID/slot when `CAL_DBG` is enabled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564947211c832882fdce12c2c45766)