### PR TITLE
RFID recovery: add failure counter, reinit path, and I2C scan command

### DIFF
--- a/syringe-filler-pio/include/app/DeviceActions.hpp
+++ b/syringe-filler-pio/include/app/DeviceActions.hpp
@@ -81,5 +81,8 @@ ActionResult readAllPots(String &data);
 // Pot-driven motion
 ActionResult potMove(uint16_t target, long sps);
 
+// Diagnostics
+ActionResult i2cScanBoth();
+
 }  // namespace DeviceActions
 }  // namespace App

--- a/syringe-filler-pio/include/hw/RFID.hpp
+++ b/syringe-filler-pio/include/hw/RFID.hpp
@@ -9,6 +9,8 @@ namespace RFID {
 
 // Call once from setup()
 void init();
+// Reinitialize the PN532 after a failure.
+void reinit();
 
 // Call every loop(); does nothing unless enabled()
 void tick();

--- a/syringe-filler-pio/src/app/CommandRouter.cpp
+++ b/syringe-filler-pio/src/app/CommandRouter.cpp
@@ -61,6 +61,7 @@ using App::DeviceActions::setServoPulseRaw;
 using App::DeviceActions::readBasePot;
 using App::DeviceActions::readAllPots;
 using App::DeviceActions::readPot;
+using App::DeviceActions::i2cScanBoth;
 
 namespace {
 struct CommandDescriptor {
@@ -389,6 +390,12 @@ void handlePotMove(const String &args) {
   printStructured("potmove", potMove(target, sps));
 }
 
+// Handle "i2cscan" command to scan both I2C buses.
+void handleI2cScan(const String &args) {
+  (void)args;
+  printStructured("i2cscan", i2cScanBoth());
+}
+
 const CommandDescriptor COMMANDS[] = {
     {"speed", "set gantry speed (steps/sec)", handleSpeed},
     {"home", "home gantry", handleHome},
@@ -434,6 +441,7 @@ const CommandDescriptor COMMANDS[] = {
     {"basepot", "read base pot", handleBasePot},
     {"pots", "read all pots", handlePotReport},
     {"potmove", "pot driven move", handlePotMove},
+    {"i2cscan", "scan both I2C buses", handleI2cScan},
 };
 
 const size_t COMMAND_COUNT = sizeof(COMMANDS) / sizeof(COMMANDS[0]);

--- a/syringe-filler-pio/src/app/DeviceActions.cpp
+++ b/syringe-filler-pio/src/app/DeviceActions.cpp
@@ -385,5 +385,11 @@ ActionResult potMove(uint16_t target, long sps) {
   return {ok, ok ? "potmove ok" : "potmove failed"};
 }
 
+// Diagnostics
+ActionResult i2cScanBoth() {
+  Drivers::i2cScanBoth();
+  return {true, "i2c scan complete"};
+}
+
 }  // namespace DeviceActions
 }  // namespace App

--- a/syringe-filler-pio/src/hw/RFID.cpp
+++ b/syringe-filler-pio/src/hw/RFID.cpp
@@ -3,6 +3,7 @@
  * @brief Toolhead RFID reader implementation on the primary I2C bus.
  */
 #include "hw/RFID.hpp"
+#include "hw/Drivers.hpp"
 #include "hw/Pins.hpp"
 
 #include <Arduino.h>
@@ -12,19 +13,50 @@
 
 // Toolhead PN532 on primary I2C bus (Wire).
 // IRQ = 27, RST = 14, same style as BaseRFID but with &Wire instead of &Wire1.
-static Adafruit_PN532 nfc(27, 14, &Wire);
+namespace {
+constexpr int kPn532IrqPin = 27;
+constexpr int kPn532RstPin = 14;
+constexpr uint8_t kPn532I2cAddr = 0x24;
+constexpr uint8_t kFailureThreshold = 3;
+}
+
+static Adafruit_PN532 nfc(kPn532IrqPin, kPn532RstPin, &Wire);
 
 // ---- State ----
 static bool    s_enabled   = false;
 static bool    s_available = false;
 static uint8_t s_uid[7]    = {0};
 static uint8_t s_uidLen    = 0;
+static uint8_t s_failures  = 0;
 
 // Listener (mirrors BaseRFID)
 static RFID::TagListener s_listener      = nullptr;
 static void*             s_listenerUser  = nullptr;
 
 namespace RFID {
+namespace {
+void pulseResetIfAvailable() {
+  if (kPn532RstPin < 0) return;
+  pinMode(kPn532RstPin, OUTPUT);
+  digitalWrite(kPn532RstPin, LOW);
+  delay(10);
+  digitalWrite(kPn532RstPin, HIGH);
+  delay(50);
+}
+
+void handleFailure(const char* reason) {
+  Serial.print(F("[RFID] read failed: "));
+  Serial.println(reason);
+  if (++s_failures < kFailureThreshold) return;
+  s_failures = 0;
+
+  if (!Drivers::i2cPresent(kPn532I2cAddr)) {
+    Serial.println(F("[RFID] PN532 missing on I2C0"));
+    pulseResetIfAvailable();
+    RFID::reinit();
+  }
+}
+} // namespace
 
 // Register a listener for newly detected tags.
 void setListener(TagListener cb, void* user) {
@@ -56,6 +88,13 @@ void init() {
   s_enabled   = false;
   s_available = false;
   s_uidLen    = 0;
+  s_failures  = 0;
+}
+
+void reinit() {
+  Serial.println(F("[RFID] reinitializing PN532"));
+  nfc.begin();
+  nfc.SAMConfig();
 }
 
 // Enable or disable RFID polling.
@@ -99,6 +138,7 @@ void tick() {
   Serial.println(success ? "YES" : "NO");
 
   if (success) {
+    s_failures = 0;
     bool changed = (uidLength != s_uidLen) || memcmp(uid, s_uid, uidLength) != 0;
     Serial.print("[RFID] success; changed=");
     Serial.println(changed ? "YES" : "NO");
@@ -122,6 +162,8 @@ void tick() {
     }
     // debounce
     delay(300);
+  } else {
+    handleFailure("tick");
   }
 
   delay(5);
@@ -134,6 +176,7 @@ bool detectOnce(uint16_t tries, uint16_t delay_ms) {
     uint8_t uid[7]; 
     uint8_t len = 0;
     if (nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &len)) {
+      s_failures = 0;
       memcpy(s_uid, uid, len);
       s_uidLen    = len;
       s_available = true;
@@ -150,6 +193,7 @@ bool detectOnce(uint16_t tries, uint16_t delay_ms) {
 
       return true;
     }
+    handleFailure("detectOnce");
     delay(delay_ms);
   }
   Serial.println(F("[RFID] No tag detected."));


### PR DESCRIPTION
### Motivation
- Improve robustness of the toolhead PN532 RFID reader by detecting repeated read failures and verifying presence on I2C before escalating recovery.
- Provide a simple recovery path (RST pulse and reinitialization) when the PN532 stops acknowledging on the primary I2C bus.
- Expose an on-demand diagnostic to scan both I2C buses for troubleshooting.

### Description
- Added `RFID::reinit()` to `include/hw/RFID.hpp` and implemented it in `src/hw/RFID.cpp` to rerun `nfc.begin()`/`SAMConfig()` for recovery.
- Introduced a failure counter `s_failures`, constants (`kFailureThreshold`, `kPn532I2cAddr`), and helper functions `handleFailure()` and `pulseResetIfAvailable()` in `src/hw/RFID.cpp`, and call `Drivers::i2cPresent()` to verify PN532 presence before logging `"[RFID] PN532 missing on I2C0"` and reinitializing.
- Reset the failure counter on successful reads and invoke the recovery sequence after repeated failures; added `#include "hw/Drivers.hpp"` to access I2C helpers.
- Added a diagnostics action `i2cScanBoth()` in `src/app/DeviceActions.cpp` and declared it in `include/app/DeviceActions.hpp`, and wired a new `i2cscan` command handler into `src/app/CommandRouter.cpp` to call `Drivers::i2cScanBoth()` on demand.

### Testing
- No automated tests were executed as part of this change.
- Basic compilation and runtime checks were not performed here (no CI run invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69578fce710883289c96a3a1004814c7)