### PR TITLE
Poll Base PN532 while moving to base (Axis move hook + in-motion RFID reads)

### DIFF
--- a/syringe-filler-pio/include/app/SyringeFillController.hpp
+++ b/syringe-filler-pio/include/app/SyringeFillController.hpp
@@ -7,6 +7,7 @@
 #include "app/SyringeCalibration.hpp"
 #include "app/Syringe.hpp"
 #include "hw/Bases.hpp"
+#include "motion/Axis.hpp"
 #include "util/Storage.hpp"   // for loadBase/saveBase etc.
 
 namespace App {
@@ -48,7 +49,7 @@ public:
 
 
 private:
-  bool     goToBase(uint8_t slot);
+  bool     goToBase(uint8_t slot, Axis::MoveHook hook = nullptr, void* context = nullptr);
   uint32_t readRFIDNow();
   uint32_t readBaseRFIDBlocking(uint32_t timeoutMs);
   uint32_t readToolheadRFIDBlocking(uint32_t timeoutMS);

--- a/syringe-filler-pio/include/motion/Axis.hpp
+++ b/syringe-filler-pio/include/motion/Axis.hpp
@@ -6,6 +6,8 @@
 #include <stdint.h>
 
 namespace Axis {
+  using MoveHook = void (*)(long errSteps, void* context);
+
   void init();
   void setSpeedSPS(long sps);  // affects step interval
   void enable(bool on);
@@ -13,6 +15,7 @@ namespace Axis {
   void stepBlocking();         // uses Pins::STEP1 timing
   void moveSteps(long steps);  // ensures Toolhead::ensureRaised() internally
   void moveTo(long targetSteps);
+  void moveToWithHook(long targetSteps, MoveHook hook, void* context);
   long current();
   void setCurrent(long s);
 }


### PR DESCRIPTION
### Motivation
- Improve reliability of Base PN532 reads by performing RFID polling while the gantry is moving toward a base instead of only after motion completes. 
- Start in-motion polling when encoder error is small so the reader sees relative motion to the tag (initial threshold chosen as `1000`).

### Description
- Add a hook type `Axis::MoveHook` and a new API `Axis::moveToWithHook` while keeping `Axis::moveTo` as a thin wrapper to support callbacks during motion. 
- Change `waitForIdle`/move logic to call the provided hook periodically while waiting for step completion so callers can run lightweight work during motion. 
- Update `SyringeFillController` to thread a `baseRfidMoveHook` through `goToBase`/`moveToWithHook` that calls `BaseRFID::tick()` while motion is in progress when `|err| <= 1000` and at most every `75 ms` using a `BaseRfidMoveScanContext`. 
- In `scanBaseSyringe` enable the `BaseRFID` listener before moving, attempt to capture a tag during movement, then disable the listener and fall back to the existing blocking read `readBaseRFIDBlocking(2000)` if no tag was captured in-motion. 
- Small API and header updates: include `motion/Axis.hpp` in the controller header and add `stdlib.h` include in the implementation file.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c0559ed88328913a1fb27a9b58b7)