### PR TITLE
Update ArduinoJson API usage to remove deprecation warnings

### DIFF
--- a/syringe-filler-pio/include/util/Recipe.hpp
+++ b/syringe-filler-pio/include/util/Recipe.hpp
@@ -70,7 +70,7 @@ struct Recipe {
     // Serialize the recipe to a JSON array.
     void toJson(JsonArray arr) const {
         for (uint8_t i = 0; i < count; ++i) {
-            JsonObject o = arr.createNestedObject();
+            JsonObject o = arr.add<JsonObject>();
             steps[i].toJson(o);
         }
     }

--- a/syringe-filler-pio/src/util/Storage.cpp
+++ b/syringe-filler-pio/src/util/Storage.cpp
@@ -256,14 +256,14 @@ static String recipePath(uint32_t toolheadRfid) {
 // RecipeDTO version
 // Save a RecipeDTO to LittleFS as JSON.
 bool saveRecipe(uint32_t toolheadRfid, const RecipeDTO& in) {
-  DynamicJsonDocument doc(2048);
+  JsonDocument doc(2048);
   char buf[16];
   snprintf(buf, sizeof(buf), "%08X", toolheadRfid);
   doc["toolhead_rfid"] = buf;
 
-  JsonArray arr = doc.createNestedArray("steps");
+  JsonArray arr = doc["steps"].to<JsonArray>();
   for (uint8_t i = 0; i < in.count; ++i) {
-    JsonObject o = arr.createNestedObject();
+    JsonObject o = arr.add<JsonObject>();
     o["base_slot"] = in.steps[i].baseSlot;
     o["ml"]        = in.steps[i].ml;
   }
@@ -280,7 +280,7 @@ bool loadRecipe(uint32_t toolheadRfid, RecipeDTO& out) {
   File f = LittleFS.open(recipePath(toolheadRfid), "r");
   if (!f) return false;
 
-  DynamicJsonDocument doc(2048);
+  JsonDocument doc(2048);
   DeserializationError err = deserializeJson(doc, f);
   f.close();
   if (err) return false;
@@ -303,8 +303,8 @@ bool saveRecipe(uint32_t toolheadRfid, const Util::Recipe& recipe) {
   File f = LittleFS.open(recipePath(toolheadRfid), "w");
   if (!f) return false;
 
-  DynamicJsonDocument doc(2048);
-  JsonArray arr = doc.createNestedArray("steps");
+  JsonDocument doc(2048);
+  JsonArray arr = doc["steps"].to<JsonArray>();
   recipe.toJson(arr);
 
   bool ok = (serializeJson(doc, f) != 0);
@@ -318,7 +318,7 @@ bool loadRecipe(uint32_t toolheadRfid, Util::Recipe& recipe) {
   File f = LittleFS.open(recipePath(toolheadRfid), "r");
   if (!f) return false;
 
-  DynamicJsonDocument doc(2048);
+  JsonDocument doc(2048);
   DeserializationError err = deserializeJson(doc, f);
   f.close();
   if (err) return false;


### PR DESCRIPTION
### Motivation
- Silence ArduinoJson deprecation warnings and use the current API for JSON construction so serialization code remains compatible with newer library versions.
- Keep recipe (de)serialization stable and avoid deprecated functions (`DynamicJsonDocument`, `createNestedArray`, `createNestedObject`).

### Description
- Replaced `DynamicJsonDocument` with `JsonDocument` in `src/util/Storage.cpp` for all recipe read/write paths.
- Replaced `createNestedArray` with `doc["steps"].to<JsonArray>()` and `createNestedObject` with `arr.add<JsonObject>()` when building recipe JSON in `src/util/Storage.cpp`.
- Updated `Util::Recipe::toJson` in `include/util/Recipe.hpp` to use `arr.add<JsonObject>()` when serializing steps.
- Adjusted corresponding load/save functions for both `RecipeDTO` and `Util::Recipe` to use the new API.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c74534688328947fca56378c5689)