### PR TITLE
Gate toolhead coupling state on raised switch

### DIFF
--- a/syringe-filler-pio/include/servo/Toolhead.hpp
+++ b/syringe-filler-pio/include/servo/Toolhead.hpp
@@ -13,5 +13,6 @@ namespace Toolhead {
   void setPulseRaw(uint8_t ch, int pulse);
   void raise();
   void couple();
+  bool isCoupled();
   bool ensureRaised(uint16_t timeout_ms = 1200);
 }

--- a/syringe-filler-pio/src/app/DeviceActions.cpp
+++ b/syringe-filler-pio/src/app/DeviceActions.cpp
@@ -20,6 +20,12 @@
 namespace App {
 namespace {
 inline long mmToSteps(float mm) { return (long)lround(mm * Pins::STEPS_PER_MM); }
+
+void ensureToolheadRaised() {
+  if (!Toolhead::isRaised()) {
+    Toolhead::raise();
+  }
+}
 }
 
 namespace DeviceActions {
@@ -43,6 +49,7 @@ ActionResult setGantrySpeed(long sps) {
 
 // Home the gantry and reset its logical position.
 ActionResult homeGantry() {
+  ensureToolheadRaised();
   Homing::home();
   return {true, "gantry homed"};
 }
@@ -51,6 +58,7 @@ ActionResult homeGantry() {
 ActionResult moveGantryToSteps(long targetSteps) {
   if (targetSteps < Pins::MIN_POS_STEPS) targetSteps = Pins::MIN_POS_STEPS;
   if (targetSteps > Pins::MAX_POS_STEPS) targetSteps = Pins::MAX_POS_STEPS;
+  ensureToolheadRaised();
   Axis::enable(true);
   Axis::moveTo(targetSteps);
   Axis::enable(false);
@@ -84,6 +92,7 @@ ActionResult moveToBase(uint8_t idx, long &targetSteps) {
   if (targetSteps < Pins::MIN_POS_STEPS || targetSteps > Pins::MAX_POS_STEPS) {
     return {false, "base target outside limits"};
   }
+  ensureToolheadRaised();
   Axis::enable(true);
   Axis::moveTo(targetSteps);
   Axis::enable(false);

--- a/syringe-filler-pio/src/app/SyringeFillController.cpp
+++ b/syringe-filler-pio/src/app/SyringeFillController.cpp
@@ -10,6 +10,7 @@
 #include "hw/RFID.hpp"
 #include "hw/BaseRFID.hpp"
 #include "util/Storage.hpp"   // Util::loadBase, Util::saveBase, Util::loadRecipe, ...
+#include "servo/Toolhead.hpp"
 #include <Arduino.h>
 #include <math.h>
 #include <stdlib.h>
@@ -503,6 +504,9 @@ bool SyringeFillController::goToBase(uint8_t slot, Axis::MoveHook hook, void* co
     Serial.println(target);
   }
 
+  if (!Toolhead::isRaised()) {
+    Toolhead::raise();
+  }
   Axis::moveToWithHook(target, hook, context);
   m_currentSlot = slot;
   if (DEBUG_FLAG) {
@@ -616,6 +620,10 @@ bool SyringeFillController::transferFromBase(uint8_t slot, float ml) {
       }
       return false;
     }
+  }
+
+  if (!Toolhead::isCoupled()) {
+    Toolhead::couple();
   }
 
   // Steps per mL derivation:

--- a/syringe-filler-pio/src/servo/Toolhead.cpp
+++ b/syringe-filler-pio/src/servo/Toolhead.cpp
@@ -26,6 +26,7 @@ static constexpr int RAMP_MS_SLOW = 17;  // increase if brownouts occur
 
 static int  s_angles[16];
 static bool s_anglesInit = false;
+static bool s_isCoupled = false;
 
 
 static inline void ensureAnglesInit() {
@@ -101,10 +102,12 @@ void raise() {
   setAngleSlow(COUPLING_SERVO, COUPLING_SERVO_DECOUPLED_POS, RAMP_MS_SLOW);
   delay(50); // small settle time
   setAngleSlow(TOOLHEAD_SERVO, TOOLHEAD_SERVO_RAISED_POS, RAMP_MS_FAST);
+  s_isCoupled = false;
 }
 
 // Run the coupling motion sequence.
 void couple() {
+  s_isCoupled = false;
   // Approach coupling position slowly, then close the coupler smoothly
   setAngleSlow(TOOLHEAD_SERVO, TOOLHEAD_SERVO_COUPLING_POS1, RAMP_MS_FAST);
   delay(100);
@@ -120,8 +123,12 @@ void couple() {
   setAngleSlow(COUPLING_SERVO, COUPLING_SERVO_COUPLED_POS, RAMP_MS_SLOW);
   delay(100);
   setPulseRaw(COUPLING_SERVO, 0);
+  s_isCoupled = isRaised();
 
+}
 
+bool isCoupled() {
+  return s_isCoupled;
 }
 
 


### PR DESCRIPTION
### Motivation
- Prevent the code from marking the toolhead as "coupled" unless the raised limit switch (`Pins::RAISED`) actually reports the toolhead as raised, avoiding a false-coupled state after the servo motion.

### Description
- Updated `src/servo/Toolhead.cpp` so `couple()` sets `s_isCoupled = isRaised()` after completing the coupling motion and ensured `raise()` (and the start of `couple()`) clear `s_isCoupled` to `false` before motion.

### Testing
- No automated tests were run because this change is hardware-dependent; manual validation with the PCA9685/servos and the raised limit switch is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d073c12883289ac90476310a58c7)