### PR TITLE
Add LittleFS recipe list/read/delete helpers and sfc.recipe.* serial commands

### DIFF
--- a/syringe-filler-pio/include/util/Storage.hpp
+++ b/syringe-filler-pio/include/util/Storage.hpp
@@ -47,5 +47,8 @@ bool saveBasePos(uint8_t idx0, long steps);
 // recipes
 bool loadRecipe(uint32_t toolheadRfid, RecipeDTO& out);
 bool saveRecipe(uint32_t toolheadRfid, const RecipeDTO& in);
+bool listRecipes(String& outJson);
+bool readRecipeJson(uint32_t toolheadRfid, String& outJson);
+bool deleteRecipe(uint32_t toolheadRfid);
 
 } // namespace Util


### PR DESCRIPTION
### Motivation
- Expose stored toolhead recipes on the device so a host/UI can list available recipes, preview recipe JSON, and delete recipes from LittleFS.
- Reuse existing structured JSON response format (`printStructured`) so new commands integrate cleanly with the existing serial protocol.

### Description
- Added API declarations to `include/util/Storage.hpp`: `listRecipes`, `readRecipeJson`, and `deleteRecipe`.
- Implemented filesystem helpers in `src/util/Storage.cpp`: `listRecipes` (enumerates `/recipes` and returns a JSON array string), `readRecipeJson` (returns raw JSON text for a recipe file), and `deleteRecipe` (removes recipe file); added `<cstring>` include for string helpers.
- Wired new serial handlers in `src/app/CommandRouter.cpp`: `handleSfcRecipeList`, `handleSfcRecipeShow`, and `handleSfcRecipeDelete`, plus a `parseRfidArg` helper; registered commands `sfc.recipe.list`, `sfc.recipe.show`, and `sfc.recipe.delete` in the `COMMANDS` table.
- All new command handlers return responses via the existing `printStructured()` JSON format for consistency with other commands.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979da36513483288e7d2bf18a608d47)