### PR TITLE
Add serial JSON recipe client and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Optional serial monitor:
 pio device monitor
 ```
 
+## Recipe JSON Client
+
+A lightweight serial JSON client is available in `syringe-filler-pio/tools/` and
+is documented in `syringe-filler-pio/docs/recipes.md`. It validates recipe JSON
+using the firmware's `Util::Recipe` schema before sending `sfc.recipe.save`.
+
 ## Serial Command Summary
 
 The main firmware prints a command list at startup. Common commands include:

--- a/syringe-filler-pio/docs/recipes.md
+++ b/syringe-filler-pio/docs/recipes.md
@@ -1,0 +1,154 @@
+# Recipe Serial JSON Protocol
+
+This document describes the JSON payloads used by the recipe-related serial
+commands and the lightweight client in `tools/sfc_recipe_client.py`.
+
+## Transport
+
+- **Request:** one JSON object per line (newline-terminated).
+- **Response:** one JSON object per line.
+- **Encoding:** UTF-8.
+
+The firmware responds in the format emitted by `printStructured()`:
+
+```json
+{
+  "cmd": "sfc.recipe.show",
+  "status": "ok",
+  "message": "optional message",
+  "data": {}
+}
+```
+
+`status` is `ok` or `error`. `message` is optional. `data` is optional and can be
+any JSON object or array.
+
+## Recipe Schema (Util::Recipe)
+
+A recipe is an **array** of steps. Each step is an object with the following
+keys:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `volume_ml` | number | yes | Must be `> 0`. |
+| `base_slot` | integer | no | 1-based base index. Must be `> 0` if provided. |
+| `base_rfid` | integer | no | RFID of the base. Must be `> 0` if provided. |
+| `color_hex` | string | no | `#RRGGBB` string. |
+| `paint_id` | integer | no | Numeric ID for the paint. Must be `> 0` if provided. |
+
+Each step must include **at least one** identifier (`base_slot`, `base_rfid`,
+`color_hex`, or `paint_id`). The maximum number of steps is **32**.
+
+Example recipe:
+
+```json
+[
+  {"volume_ml": 1.5, "base_slot": 1},
+  {"volume_ml": 0.75, "color_hex": "#12ABEF", "paint_id": 42}
+]
+```
+
+## Commands
+
+### `sfc.recipe.list`
+
+List the stored recipes.
+
+**Request**
+
+```json
+{"cmd":"sfc.recipe.list"}
+```
+
+**Response data** (example):
+
+```json
+{
+  "recipes": [
+    {"toolhead_rfid": 3735928559},
+    {"toolhead_rfid": 305419896}
+  ]
+}
+```
+
+### `sfc.recipe.show`
+
+Show a stored recipe by toolhead RFID.
+
+**Request**
+
+```json
+{"cmd":"sfc.recipe.show","data":{"toolhead_rfid":305419896}}
+```
+
+**Response data** (example):
+
+```json
+{
+  "toolhead_rfid": 305419896,
+  "recipe": [
+    {"volume_ml": 1.5, "base_slot": 1}
+  ]
+}
+```
+
+### `sfc.recipe.save`
+
+Save a recipe for a toolhead RFID.
+
+**Request**
+
+```json
+{
+  "cmd": "sfc.recipe.save",
+  "data": {
+    "toolhead_rfid": 305419896,
+    "recipe": [
+      {"volume_ml": 1.5, "base_slot": 1}
+    ]
+  }
+}
+```
+
+**Response data** (example):
+
+```json
+{"saved":true}
+```
+
+### `sfc.recipe.delete`
+
+Delete a stored recipe by toolhead RFID.
+
+**Request**
+
+```json
+{"cmd":"sfc.recipe.delete","data":{"toolhead_rfid":305419896}}
+```
+
+**Response data** (example):
+
+```json
+{"deleted":true}
+```
+
+## CLI Usage
+
+The Python CLI sends the JSON payloads above and prints the JSON response.
+Install dependencies first:
+
+```bash
+pip install pyserial
+```
+
+Examples:
+
+```bash
+tools/sfc_recipe_client.py --port /dev/ttyUSB0 list
+
+tools/sfc_recipe_client.py --port /dev/ttyUSB0 show 0x1234ABCD
+
+tools/sfc_recipe_client.py --port /dev/ttyUSB0 save 0x1234ABCD ./recipe.json
+
+tools/sfc_recipe_client.py --port /dev/ttyUSB0 delete 0x1234ABCD
+```

--- a/syringe-filler-pio/tools/sfc_recipe_client.py
+++ b/syringe-filler-pio/tools/sfc_recipe_client.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Serial JSON recipe client for the syringe filler."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+try:
+    import serial  # type: ignore
+except ImportError:  # pragma: no cover - runtime dependency
+    serial = None
+
+
+RECIPE_MAX_STEPS = 32
+COLOR_HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+@dataclass
+class ValidationError:
+    index: Optional[int]
+    message: str
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def validate_recipe_steps(steps: Iterable[Dict[str, Any]]) -> List[ValidationError]:
+    errors: List[ValidationError] = []
+    steps_list = list(steps)
+
+    if not steps_list:
+        errors.append(ValidationError(None, "recipe must have at least one step"))
+        return errors
+
+    if len(steps_list) > RECIPE_MAX_STEPS:
+        errors.append(
+            ValidationError(None, f"recipe has {len(steps_list)} steps (max {RECIPE_MAX_STEPS})")
+        )
+
+    for idx, step in enumerate(steps_list):
+        if not isinstance(step, dict):
+            errors.append(ValidationError(idx, "step must be an object"))
+            continue
+
+        volume = step.get("volume_ml")
+        if not isinstance(volume, (int, float)) or volume <= 0:
+            errors.append(ValidationError(idx, "volume_ml must be a positive number"))
+
+        base_slot = step.get("base_slot")
+        base_rfid = step.get("base_rfid")
+        color_hex = step.get("color_hex")
+        paint_id = step.get("paint_id")
+
+        identifiers = [
+            _is_positive_int(base_slot),
+            _is_positive_int(base_rfid),
+            isinstance(color_hex, str) and bool(color_hex.strip()),
+            _is_positive_int(paint_id),
+        ]
+        if not any(identifiers):
+            errors.append(
+                ValidationError(
+                    idx,
+                    "step requires an identifier (base_slot, base_rfid, color_hex, or paint_id)",
+                )
+            )
+
+        if base_slot is not None and not _is_positive_int(base_slot):
+            errors.append(ValidationError(idx, "base_slot must be a positive integer"))
+        if base_rfid is not None and not _is_positive_int(base_rfid):
+            errors.append(ValidationError(idx, "base_rfid must be a positive integer"))
+        if paint_id is not None and not _is_positive_int(paint_id):
+            errors.append(ValidationError(idx, "paint_id must be a positive integer"))
+
+        if color_hex is not None:
+            if not isinstance(color_hex, str) or not COLOR_HEX_RE.match(color_hex):
+                errors.append(ValidationError(idx, "color_hex must look like #RRGGBB"))
+
+    return errors
+
+
+def parse_recipe_payload(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and "steps" in payload:
+        if isinstance(payload["steps"], list):
+            return payload["steps"]
+    raise ValueError("recipe JSON must be an array or an object with a 'steps' array")
+
+
+def parse_rfid(value: str) -> int:
+    try:
+        return int(value, 0)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("RFID must be an integer (decimal or 0xHEX)") from exc
+
+
+def ensure_serial_available() -> None:
+    if serial is None:
+        raise SystemExit("pyserial is required: pip install pyserial")
+
+
+def open_serial(port: str, baud: int, timeout: float):
+    ensure_serial_available()
+    return serial.Serial(port=port, baudrate=baud, timeout=timeout)
+
+
+def send_command(ser, payload: Dict[str, Any]) -> None:
+    line = json.dumps(payload, separators=(",", ":"))
+    ser.write((line + "\n").encode("utf-8"))
+    ser.flush()
+
+
+def read_response(ser, timeout: float) -> Dict[str, Any]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        raw = ser.readline()
+        if not raw:
+            continue
+        text = raw.decode("utf-8", errors="replace").strip()
+        if not text:
+            continue
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            continue
+    raise TimeoutError("timed out waiting for JSON response")
+
+
+def print_response(response: Dict[str, Any], pretty: bool) -> None:
+    if pretty:
+        print(json.dumps(response, indent=2))
+    else:
+        print(json.dumps(response))
+
+
+def handle_list(args: argparse.Namespace) -> Dict[str, Any]:
+    return {"cmd": "sfc.recipe.list"}
+
+
+def handle_show(args: argparse.Namespace) -> Dict[str, Any]:
+    return {"cmd": "sfc.recipe.show", "data": {"toolhead_rfid": args.toolhead_rfid}}
+
+
+def handle_delete(args: argparse.Namespace) -> Dict[str, Any]:
+    return {"cmd": "sfc.recipe.delete", "data": {"toolhead_rfid": args.toolhead_rfid}}
+
+
+def handle_save(args: argparse.Namespace) -> Dict[str, Any]:
+    with open(args.recipe, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    steps = parse_recipe_payload(payload)
+    errors = validate_recipe_steps(steps)
+    if errors:
+        for err in errors:
+            prefix = f"step {err.index + 1}: " if err.index is not None else ""
+            print(f"validation error: {prefix}{err.message}", file=sys.stderr)
+        raise SystemExit(2)
+    return {
+        "cmd": "sfc.recipe.save",
+        "data": {
+            "toolhead_rfid": args.toolhead_rfid,
+            "recipe": steps,
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Syringe filler recipe serial client")
+    parser.add_argument("--port", required=True, help="Serial device path, e.g. /dev/ttyUSB0")
+    parser.add_argument("--baud", type=int, default=115200, help="Serial baud rate")
+    parser.add_argument("--timeout", type=float, default=3.0, help="Seconds to wait for JSON")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON response")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List stored recipes")
+
+    show_parser = subparsers.add_parser("show", help="Show a specific recipe")
+    show_parser.add_argument("toolhead_rfid", type=parse_rfid, help="Toolhead RFID")
+
+    save_parser = subparsers.add_parser("save", help="Save a recipe")
+    save_parser.add_argument("toolhead_rfid", type=parse_rfid, help="Toolhead RFID")
+    save_parser.add_argument("recipe", help="Path to recipe JSON file")
+
+    delete_parser = subparsers.add_parser("delete", help="Delete a stored recipe")
+    delete_parser.add_argument("toolhead_rfid", type=parse_rfid, help="Toolhead RFID")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "list":
+        payload = handle_list(args)
+    elif args.command == "show":
+        payload = handle_show(args)
+    elif args.command == "save":
+        payload = handle_save(args)
+    elif args.command == "delete":
+        payload = handle_delete(args)
+    else:
+        parser.error("unknown command")
+        return
+
+    try:
+        with open_serial(args.port, args.baud, args.timeout) as ser:
+            send_command(ser, payload)
+            response = read_response(ser, args.timeout)
+    except TimeoutError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    print_response(response, args.pretty)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a lightweight client to interact with the firmware's serial JSON recipe commands and make it easy to list/show/save/delete recipes. 
- Ensure the client enforces the same recipe constraints as the firmware's `Util::Recipe` type so invalid recipes are caught before being sent. 
- Document the request/response payloads and schema so integrators (CLI/web clients) can interoperate with the device reliably.

### Description

- Add a Python CLI serial client `syringe-filler-pio/tools/sfc_recipe_client.py` that sends newline-terminated JSON requests and reads JSON responses, supporting `sfc.recipe.list`, `sfc.recipe.show`, `sfc.recipe.save`, and `sfc.recipe.delete`.
- Implement schema/format validation in the client matching `Util::Recipe` rules (positive `volume_ml`, at least one identifier of `base_slot`/`base_rfid`/`color_hex`/`paint_id`, `color_hex` pattern `#RRGGBB`, and a 32-step maximum); client accepts either an array or an object with a `steps` array as input.
- Add protocol documentation `syringe-filler-pio/docs/recipes.md` describing transport, the `Util::Recipe` schema, example payloads, response format, and CLI usage examples.
- Link the new client/docs from the top-level `README.md`.

### Testing

- No automated tests were run as part of this change (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979da3ab5788328a36785f2be85f2aa)