### PR TITLE
WebUI: add machine control buttons, VREF telemetry, and recipe repeat support

### DIFF
--- a/syringe-filler-multiple/include/app/CommandRouter.hpp
+++ b/syringe-filler-multiple/include/app/CommandRouter.hpp
@@ -3,6 +3,8 @@
  * @brief Serial command parsing and dispatch.
  */
 #pragma once
+#include <Arduino.h>
 namespace CommandRouter {
   void handleSerial();
+  bool executeCommandLine(const String &line, String &responseJson);
 }

--- a/syringe-filler-multiple/include/hw/Pots.hpp
+++ b/syringe-filler-multiple/include/hw/Pots.hpp
@@ -14,6 +14,7 @@ namespace Pots {
 
   // Sample ADS0:A0 (VREF/3.3V rail) and emit structured WARN logs on low-rail events.
   void monitorVref(const char *context = nullptr);
+  float latestVrefVolts();
 
   // ADS native counts (0..32767 at GAIN_ONE)
   uint16_t raw(uint8_t i);

--- a/syringe-filler-multiple/src/app/CommandRouter.cpp
+++ b/syringe-filler-multiple/src/app/CommandRouter.cpp
@@ -93,6 +93,7 @@ struct CommandDescriptor {
 static String input;
 static App::SyringeFillController g_sfc;
 static Shared::WifiManager g_wifi;
+static String *g_responseSink = nullptr;
 
 // ------------------------------------------------------------
 // Shared command utilities
@@ -100,23 +101,28 @@ static Shared::WifiManager g_wifi;
 
 // Emit a JSON response for a simple action result.
 void printStructured(const char *cmd, const ActionResult &res, const String &data = "") {
-  Serial.print("{\"cmd\":\"");
-  Serial.print(cmd);
-  Serial.print("\",\"status\":\"");
-  Serial.print(res.ok ? "ok" : "error");
-  Serial.print("\"");
+  String line = "{\"cmd\":\"";
+  line += cmd;
+  line += "\",\"status\":\"";
+  line += (res.ok ? "ok" : "error");
+  line += "\"";
   if (res.message.length()) {
-    Serial.print(",\"message\":\"");
-    Serial.print(res.message);
-    Serial.print("\"");
+    line += ",\"message\":\"";
+    line += res.message;
+    line += "\"";
   }
   if (data.length()) {
     String formattedData = data;
     formattedData.replace("},{", "},\n{");
-    Serial.print(",\"data\":");
-    Serial.print(formattedData);
+    line += ",\"data\":";
+    line += formattedData;
   }
-  Serial.println("}");
+  line += "}";
+  if (g_responseSink) {
+    *g_responseSink = line;
+    return;
+  }
+  Serial.println(line);
 }
 
 // Emit a JSON response for a position result with steps/mm.
@@ -317,7 +323,26 @@ void handleSfcScanAllBaseSyringes(const String &args) {
 }
 
 // Handle "sfc.run" command to execute the recipe.
-void handleSfcRun(const String &args) { printStructured("sfc.run", sfcRunRecipe(g_sfc)); }
+void handleSfcRun(const String &args) {
+  String trimmed = args;
+  trimmed.trim();
+  uint16_t repeats = 1;
+  if (trimmed.length() > 0) {
+    long parsed = trimmed.toInt();
+    if (parsed <= 0 || parsed > 997) {
+      printStructured("sfc.run", {false, "usage: sfc.run [repeat_count 1..997]"});
+      return;
+    }
+    repeats = static_cast<uint16_t>(parsed);
+  }
+  ActionResult lastRes{true, "recipe completed"};
+  for (uint16_t i = 0; i < repeats; ++i) {
+    lastRes = sfcRunRecipe(g_sfc);
+    if (!lastRes.ok) break;
+  }
+  String data = "{\"repeatCount\":" + String(repeats) + "}";
+  printStructured("sfc.run", lastRes, data);
+}
 
 // Handle "sfc.load" command to load a recipe.
 void handleSfcLoad(const String &args) {
@@ -915,6 +940,25 @@ const CommandDescriptor *lookupCommand(const String &verb) {
   return nullptr;
 }
 
+void executeCommand(const String &verb, const String &args, String *responseJson) {
+  const CommandDescriptor *cmd = lookupCommand(verb);
+  if (responseJson) {
+    g_responseSink = responseJson;
+    *responseJson = "";
+  }
+  if (cmd) {
+    String beforeContext = "cmd.pre " + verb;
+    String afterContext = "cmd.post " + verb;
+    Pots::monitorVref(beforeContext.c_str());
+    cmd->handler(args);
+    Pots::monitorVref(afterContext.c_str());
+  } else {
+    ActionResult res{false, "unknown command"};
+    printStructured(verb.c_str(), res);
+  }
+  g_responseSink = nullptr;
+}
+
 }  // namespace
 
 // Read serial input and dispatch the matching command handler.
@@ -932,24 +976,28 @@ void handleSerial() {
       String verb = (spaceIndex > 0) ? input.substring(0, spaceIndex) : input;
       String args = (spaceIndex > 0) ? input.substring(spaceIndex + 1) : "";
       args.trim();
-
-      const CommandDescriptor *cmd = lookupCommand(verb);
-      if (cmd) {
-        String beforeContext = "cmd.pre " + verb;
-        String afterContext = "cmd.post " + verb;
-        Pots::monitorVref(beforeContext.c_str());
-        cmd->handler(args);
-        Pots::monitorVref(afterContext.c_str());
-      } else {
-        ActionResult res{false, "unknown command"};
-        printStructured(verb.c_str(), res);
-      }
+      executeCommand(verb, args, nullptr);
 
       input = "";
     } else if (c != '\r') {
       input += c;
     }
   }
+}
+
+bool executeCommandLine(const String &line, String &responseJson) {
+  String command = line;
+  command.trim();
+  if (command.length() == 0) {
+    responseJson = "{\"cmd\":\"\",\"status\":\"error\",\"message\":\"empty command\"}";
+    return false;
+  }
+  int spaceIndex = command.indexOf(' ');
+  String verb = (spaceIndex > 0) ? command.substring(0, spaceIndex) : command;
+  String args = (spaceIndex > 0) ? command.substring(spaceIndex + 1) : "";
+  args.trim();
+  executeCommand(verb, args, &responseJson);
+  return responseJson.indexOf("\"status\":\"ok\"") >= 0;
 }
 
 }  // namespace CommandRouter

--- a/syringe-filler-multiple/src/app/WebUI.cpp
+++ b/syringe-filler-multiple/src/app/WebUI.cpp
@@ -11,6 +11,8 @@
 #include <WifiCredentials.hpp>
 #include <WifiManager.hpp>
 
+#include "app/CommandRouter.hpp"
+#include "hw/Pots.hpp"
 #include "util/Recipe.hpp"
 #include "util/Storage.hpp"
 
@@ -42,6 +44,9 @@ const char kIndexHtml[] PROGMEM = R"HTML(
     input[type="number"], input[type="text"] { width: 100%; padding: 6px; }
     button { margin: 4px 4px 4px 0; padding: 6px 10px; }
     .muted { color: #666; font-size: 0.9em; }
+    .chip { display: inline-block; border-radius: 999px; padding: 4px 10px; margin: 0 6px 6px 0; background: #ececec; color: #444; }
+    .chip.ok { background: #d8f6e4; color: #186a3b; }
+    .chip.bad { background: #ffe0e0; color: #9b2226; }
   </style>
 </head>
 <body>
@@ -69,15 +74,47 @@ const char kIndexHtml[] PROGMEM = R"HTML(
       <div id="status" class="muted"></div>
     </div>
   </div>
+
+  <div class="row" style="margin-top: 16px;">
+    <div class="col panel">
+      <h3>Machine Controls</h3>
+      <button id="cmdHome">home</button>
+      <button id="cmdScanAll">scanall</button>
+      <button id="cmdScanTool">scantool</button>
+      <button id="cmdInitAll">initializeall</button>
+      <button id="cmdLoad">load</button>
+      <button id="cmdRun">run</button>
+      <label>Run repeats</label>
+      <input id="repeatCount" type="number" min="1" value="5" />
+      <div class="muted">run repeats execute the currently loaded recipe count times.</div>
+      <div id="commandStatus" class="muted"></div>
+    </div>
+
+    <div class="col panel">
+      <h3>Init Status</h3>
+      <div id="initIndicators" class="muted">Not initialized yet.</div>
+      <h3>Latest VREF</h3>
+      <div id="vrefStatus" class="muted">--</div>
+    </div>
+  </div>
+
   <script>
     const listEl = document.getElementById('recipeList');
     const stepsEl = document.getElementById('steps');
     const recipeIdEl = document.getElementById('recipeId');
     const statusEl = document.getElementById('status');
+    const commandStatusEl = document.getElementById('commandStatus');
+    const initIndicatorsEl = document.getElementById('initIndicators');
+    const vrefStatusEl = document.getElementById('vrefStatus');
 
     function setStatus(msg, ok = true) {
       statusEl.textContent = msg;
       statusEl.style.color = ok ? '#2b6' : '#c33';
+    }
+
+    function setCommandStatus(msg, ok = true) {
+      commandStatusEl.textContent = msg;
+      commandStatusEl.style.color = ok ? '#2b6' : '#c33';
     }
 
     function addRow(step = { volume_ml: 1, base_slot: 0 }) {
@@ -89,6 +126,50 @@ const char kIndexHtml[] PROGMEM = R"HTML(
       `;
       tr.querySelector('.remove').onclick = () => tr.remove();
       stepsEl.appendChild(tr);
+    }
+
+    function renderInitIndicators(result) {
+      const steps = result?.data?.steps;
+      if (!steps) {
+        initIndicatorsEl.innerHTML = '<span class="chip">No init data yet</span>';
+        return;
+      }
+      const order = ['home', 'scantool', 'sfc.scanall', 'recipe.list', 'sfc.status'];
+      initIndicatorsEl.innerHTML = order.map(key => {
+        const entry = steps[key] || { ok: false, message: 'missing' };
+        const cls = entry.ok ? 'chip ok' : 'chip bad';
+        return `<span class="${cls}">${key}: ${entry.ok ? 'ok' : 'error'} (${entry.message || ''})</span>`;
+      }).join('');
+    }
+
+    async function sendCommand(command) {
+      const resp = await fetch('/api/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command })
+      });
+      if (!resp.ok) {
+        const txt = await resp.text();
+        throw new Error(txt || 'command failed');
+      }
+      return resp.json();
+    }
+
+    async function refreshVref() {
+      try {
+        const resp = await fetch('/api/telemetry');
+        const data = await resp.json();
+        const vref = Number(data.latest_vref_volts);
+        if (Number.isFinite(vref)) {
+          vrefStatusEl.textContent = `${vref.toFixed(3)} V`;
+          vrefStatusEl.style.color = vref >= 3.0 ? '#2b6' : '#c33';
+        } else {
+          vrefStatusEl.textContent = '--';
+        }
+      } catch (err) {
+        vrefStatusEl.textContent = `telemetry error: ${err.message}`;
+        vrefStatusEl.style.color = '#c33';
+      }
     }
 
     async function refreshList() {
@@ -163,7 +244,48 @@ const char kIndexHtml[] PROGMEM = R"HTML(
     document.getElementById('save').onclick = saveRecipe;
     document.getElementById('del').onclick = deleteRecipe;
 
+    document.getElementById('cmdHome').onclick = async () => {
+      const r = await sendCommand('home');
+      setCommandStatus(r.message || 'home complete', r.status === 'ok');
+      refreshVref();
+    };
+    document.getElementById('cmdScanAll').onclick = async () => {
+      const r = await sendCommand('sfc.scanall');
+      setCommandStatus(r.message || 'scanall complete', r.status === 'ok');
+      refreshVref();
+    };
+    document.getElementById('cmdScanTool').onclick = async () => {
+      const r = await sendCommand('scantool');
+      setCommandStatus(r.message || 'scantool complete', r.status === 'ok');
+      refreshVref();
+    };
+    document.getElementById('cmdInitAll').onclick = async () => {
+      const r = await sendCommand('initializeall');
+      setCommandStatus(r.message || 'initializeall complete', r.status === 'ok');
+      renderInitIndicators(r);
+      refreshVref();
+    };
+    document.getElementById('cmdLoad').onclick = async () => {
+      const recipeId = recipeIdEl.value.trim();
+      if (!recipeId) return setCommandStatus('Recipe ID is required for load.', false);
+      const r = await sendCommand(`sfc.load ${recipeId}`);
+      setCommandStatus(r.message || 'load complete', r.status === 'ok');
+      refreshVref();
+    };
+    document.getElementById('cmdRun').onclick = async () => {
+      const repeats = parseInt(document.getElementById('repeatCount').value || '1', 10);
+      if (!Number.isFinite(repeats) || repeats < 1) {
+        setCommandStatus('Repeat count must be >= 1', false);
+        return;
+      }
+      const r = await sendCommand(`sfc.run ${repeats}`);
+      setCommandStatus(r.message || 'run complete', r.status === 'ok');
+      refreshVref();
+    };
+
     refreshList();
+    refreshVref();
+    setInterval(refreshVref, 2053);
   </script>
 </body>
 </html>
@@ -185,6 +307,39 @@ void sendJson(const JsonDocument& doc) {
   String body;
   serializeJson(doc, body);
   server.send(200, "application/json", body);
+}
+
+void handleCommandApi() {
+  if (server.method() != HTTP_POST) {
+    server.send(405, "text/plain", "Method not allowed");
+    return;
+  }
+  if (!server.hasArg("plain")) {
+    server.send(400, "text/plain", "Missing body");
+    return;
+  }
+  JsonDocument requestDoc;
+  DeserializationError err = deserializeJson(requestDoc, server.arg("plain"));
+  if (err) {
+    server.send(400, "text/plain", "Invalid JSON");
+    return;
+  }
+  String command = requestDoc["command"].as<String>();
+  command.trim();
+  if (command.length() == 0) {
+    server.send(400, "text/plain", "Missing command");
+    return;
+  }
+
+  String responseJson;
+  CommandRouter::executeCommandLine(command, responseJson);
+  server.send(200, "application/json", responseJson);
+}
+
+void handleTelemetryApi() {
+  JsonDocument doc;
+  doc["latest_vref_volts"] = Pots::latestVrefVolts();
+  sendJson(doc);
 }
 
 void handleListRecipes() {
@@ -351,6 +506,8 @@ void begin() {
     server.send_P(200, "text/html", kIndexHtml);
   });
   server.on("/api/recipes", HTTP_ANY, handleApiRecipes);
+  server.on("/api/command", HTTP_ANY, handleCommandApi);
+  server.on("/api/telemetry", HTTP_GET, handleTelemetryApi);
   server.onNotFound(handleApiRecipeItem);
 
   server.begin();

--- a/syringe-filler-multiple/src/hw/Pots.cpp
+++ b/syringe-filler-multiple/src/hw/Pots.cpp
@@ -44,6 +44,7 @@ static bool     inited = false;
 static bool     s_vref_was_low = false;
 static float    s_vref_low_min_volts = ADS_FULL_SCALE_VOLTS;
 static float    s_vref_last_logged_low_volts = ADS_FULL_SCALE_VOLTS;
+static float    s_vref_latest_volts = ADS_FULL_SCALE_VOLTS;
 static uint16_t pot_raw[NUM_POTS];
 static uint16_t pot_filt[NUM_POTS];
 static uint16_t pot_last_reported[NUM_POTS];
@@ -76,6 +77,7 @@ static void monitor_vref(uint16_t vref_counts, const char *context) {
   if (!s_ads_present[VREF_ADS]) return;
 
   const float vref_volts = counts_to_volts(vref_counts);
+  s_vref_latest_volts = vref_volts;
   const bool vref_low = (vref_volts < VREF_WARN_THRESHOLD_VOLTS);
 
   auto print_context = [&]() {
@@ -198,6 +200,11 @@ void poll() {
 void monitorVref(const char *context) {
   if (!inited) init();
   monitor_vref(read_vref_counts(), context);
+}
+
+float latestVrefVolts() {
+  if (!inited) init();
+  return s_vref_latest_volts;
 }
 
 // Return the last raw counts for a pot index.


### PR DESCRIPTION
### Motivation
- Provide web-accessible machine controls so the same CommandRouter actions available over serial can be driven from the browser UI. 
- Surface post-init step status and the latest ADC VREF reading in the WebUI to help operators confirm devices initialized correctly. 
- Allow a recipe to be executed multiple times in a row from the UI (repeat runs) without requiring repeated manual commands.

### Description
- Added `CommandRouter::executeCommandLine()` and a small execution wrapper that captures structured JSON responses (via an internal `g_responseSink`) so web callers can invoke the same handlers used by the serial console. 
- Extended `sfc.run` to accept an optional repeat count (`sfc.run [repeat_count]`) and run the loaded recipe that many times, returning the repeat count in the response. 
- Added VREF tracking to `Pots` (`latestVrefVolts()` and a tracked `s_vref_latest_volts`) and updated `monitor_vref()` to update the latest value. 
- Added WebUI endpoints `POST /api/command` to run arbitrary command strings and `GET /api/telemetry` to return the latest VREF value, and updated the embedded UI to include buttons for `home`, `scanall`, `scantool`, `initializeall`, `load`, and `run`, plus per-step init status chips and a latest-VREF display polled every `2053` ms. 
- Adjusted `printStructured` to emit JSON into the response sink when a web caller is present so responses remain structured and consistent between serial and web callers.

### Testing
- Attempted an automated firmware build with `pio run -d syringe-filler-multiple`, however PlatformIO (`pio`) is not available in this environment so the build could not be executed (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa0ac0b508328a8cf2e2850ef5796)